### PR TITLE
Config patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ research_resources/*
 public/uploads/*
 db/schema.rb
 /db/schema.rb
-/config/application.rb

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,0 +1,19 @@
+require_relative 'boot'
+
+require 'rails/all'
+
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
+
+
+
+# config.generators.test_framework :rspec
+
+module Marvl
+  class Application < Rails::Application
+    # Settings in config/environments/* take precedence over those specified here.
+    # Application configuration should go into files in config/initializers
+    # -- all .rb files in that directory are automatically loaded.
+  end
+end


### PR DESCRIPTION
absence of config/application.rb is breaking production. since this file does not contain any secrets or data, i see no reason to keep it excluded from version control. merging my own PR to get production running again and up to date so I can get the data in for the demo
